### PR TITLE
added test cases and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The full list of labels which can be specified are:
 ```
   HAPROXY_GROUP
     The group of marathon-lb instances that point to the service.
+    This is a global group for all services running on different vhosts in a application
+    This can be overrided for each service port. If it is not overriden this will be default group.
     Load balancers with the group '*' will collect all groups.
 
   HAPROXY_DEPLOYMENT_GROUP
@@ -200,6 +202,28 @@ The full list of labels which can be specified are:
     Bind to the specific port for the service.
     This overrides the servicePort which has to be unique.
     Ex: HAPROXY_0_PORT = 80
+
+  HAPROXY_{n}_GROUP
+    Haproxy group per service. This helps us have different HA Proxy groups per service port.
+    This overrides HAPROXY_GROUP for the particular service.
+    If you have both external and internal services running on same set of instances on 
+    different ports, you can use this feature to add them to different haproxy configs.
+    Ex: HAPROXY_0_GROUP = 'external'
+        HAPROXY_1_GROUP = 'internal'
+
+    Now if you run marathon_lb with --group external, it just adds the service on HAPROXY_0_PORT 
+    (or first service port incase HAPROXY_0_HOST is not configured) to haproxy config and similarly 
+    if you run it with --group internal, it adds service on HAPROXY_1_PORT to haproxy config.
+    If the configuration is a combination of HAPROXY_GROUP and HAPROXY_{n}_GROUP, 
+    the more specific definition takes precedence.
+    Ex: HAPROXY_0_GROUP = 'external'
+        HAPROXY_GROUP   = 'internal'
+
+    Considering the above example where the configuration is hybrid, Service running on 
+    HAPROXY_0_PORT is associated with just 'external' haproxy group and not 'internal' group.
+    And since there is no Haproxy group mentioned for second service (HAPROXY_1_GROUP not defined) 
+    it falls back to default HAPROXY_GROUP and gets associated with 'internal' group.
+
 
   HAPROXY_{n}_MODE
     Set the connection mode to either TCP or HTTP. The default is TCP.

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -638,3 +638,139 @@ backend nginx_10000
   server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11 port 1024
 '''
         self.assertMultiLineEqual(config, expected)
+
+    def test_config_haproxy_group_fallback(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app1.groups = ['external', 'internal']
+        app1.add_backend("1.1.1.1", 1024, False)
+        app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        app2.groups = ['external', 'internal']
+        app2.add_backend("1.1.1.1", 1025, False)
+        apps = [app1, app2]
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode tcp
+  use_backend nginx_10000
+
+frontend nginx_10001
+  bind *:10001
+  mode tcp
+  use_backend nginx_10001
+
+backend nginx_10000
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1024 1.1.1.1:1024
+
+backend nginx_10001
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1025 1.1.1.1:1025
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_haproxy_group_per_service(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app1.haproxy_groups = ['external']
+        app1.add_backend("1.1.1.1", 1024, False)
+        app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        app2.haproxy_groups = ['internal']
+        app2.add_backend("1.1.1.1", 1025, False)
+        apps = [app1, app2]
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode tcp
+  use_backend nginx_10000
+
+backend nginx_10000
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1024 1.1.1.1:1024
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_haproxy_group_hybrid(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app1.haproxy_groups = ['internal']
+        app1.add_backend("1.1.1.1", 1024, False)
+        app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        app2.groups = ['external']
+        app2.add_backend("1.1.1.1", 1025, False)
+        apps = [app1, app2]
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10001
+  bind *:10001
+  mode tcp
+  use_backend nginx_10001
+
+backend nginx_10001
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1025 1.1.1.1:1025
+'''
+        self.assertMultiLineEqual(config, expected)


### PR DESCRIPTION
Added test cases for

1. Fallback to HAPROXY_GROUP label for 2 services(on same hosts) when HAPROXY_{n}_GROUP is not specified for any of the services.
2. Using new HAPROXY_{n}_GROUP label with 2 different services(on same hosts), with each service being associated with a different haproxy_group.
3. Hybrid Config where HAPROXY_0_GROUP is specified for first service and HAPROXY_GROUP is also specified without specifying HAPROXY_1_GROUP for second service.

Added documentation as well.